### PR TITLE
Fixed app's background and text color styles. Version 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,3 +12,8 @@ Alt: end of ASCII art
 ## Version 0.0.1
 
 - **Intitialized as a Next.js app.** Weather App is something that users will open several times a day for short sessions: a minute or less. It is expected that the App loads instantly. This is why I consider making this app load server side and push prerendered html to it's users.
+
+## Version 0.0.2
+
+- **Fixed app's background and text color styles.** Next.js automatic conversion have broken app's background. `<div id="root">` element disappeared from html because it was defined in public/index.html. It was used in `CRA` version of this app. Fixed it by adding an `id="root"` attribute to the root div node.
+- **Deleted `public/index.html` file.** Should have deleted it in the previous PR, but later is better than never.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "private": true,
   "dependencies": {
     "next": "^13.4.10",

--- a/public/index.html
+++ b/public/index.html
@@ -1,1 +1,0 @@
-<div id="root"></div>

--- a/src/App.js
+++ b/src/App.js
@@ -51,7 +51,7 @@ export default function App() {
   }, []);
 
   return (
-    <div>
+    <div id="root">
       <div className="header">
         <div className="location">{current.location.name}</div>
         <div className="temp">{current.temp}</div>


### PR DESCRIPTION
- **Fixed app's background and text color styles.** Next.js automatic conversion have broken app's background. `<div id="root">` element disappeared from html because it was defined in public/index.html. It was used in `CRA` version of this app. Fixed it by adding an `id="root"` attribute to the root div node.
- **Deleted `public/index.html` file.** Should have deleted it in the previous PR, but later is better than never.