### PR TITLE
Display city name detected via IP address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 0.0.4
+
+- **Display city name detected via IP address.** I used free [geoplugin.com](https://www.geoplugin.com/) service. In order to test different IP addresses locally you can set `TESTING_FAKE_IP_ADDRESS` env variable in `.env.local` file.
+- **Added logging to stderr and stdout.** Most hosting providers give you a way to read these logs, which is probably enough for this simple app.
+- **Removed IP address from UI.** Now we will test that city is detected. I will test it by using different VPN locations.
+
 ## Version 0.0.3
 
 - **Rewrite in Typescript.** Created typescript interfaces via [VS Code extension "JSON to TS"](https://marketplace.visualstudio.com/items?itemName=MariusAlchimavicius.json-to-ts) from fake data in [data.ts](src/data.ts) and put them in [weatherTypes.ts](src/weatherTypes.ts). Then converted all \*.js files to typescript.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "dependencies": {
     "next": "^13.4.10",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,18 +12,15 @@ export interface IAppProps {
   currentWeather: ICurrentWeather;
   hourly: IHoulyItem[];
   dailyForecast: IDailyForecastItem[];
-  detectedIp: string;
 }
 
 export default function App(props: IAppProps) {
-  const { dailyForecast, currentWeather, hourly, detectedIp } = props;
+  const { dailyForecast, currentWeather, hourly } = props;
 
   return (
     <div id="root">
       <div className="header">
-        <div className="location">
-          {currentWeather.location.name}, IP: {detectedIp}
-        </div>
+        <div className="location">{currentWeather.location.name}</div>
 
         <div className="temp">{currentWeather.temp}</div>
         <div className="conditions">


### PR DESCRIPTION
- **Display city name detected via IP address.** I used free [geoplugin.com](https://www.geoplugin.com/) service. In order to test different IP addresses locally you can set `TESTING_FAKE_IP_ADDRESS` env variable in `.env.local` file.
- **Added logging to stderr and stdout.** Most hosting providers give you a way to read these logs, which is probably enough for this simple app.
- **Removed IP address from UI.** Now we will test that city is detected. I will test it by using different VPN locations.